### PR TITLE
Remove mogenius from deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,6 @@
 <br>
   <a href="https://github.com/codespaces/new"><img title="A17 on Gitub Codespace" src="https://img.shields.io/badge/DEPLOY CODESPACE-h?color=black&style=for-the-badge&logo=visualstudiocode" />
 </a>
-  <br>
-<br>
-  <a href="https://studio.mogenius.com/studio/cloud-space/cloud-space-overview"><img title="A17 on Mogenius" src="https://img.shields.io/badge/DEPLOY MOGENIUS-h?color=blue&style=for-the-badge&logo=genius"></a>
-</a>
 
 # Install Manually 👇
 


### PR DESCRIPTION
Hi there, mogenius doesn't offer free cloud resources anymore. It is still possible to deploy containers on the free plan but it requires setting up a local Kubernetes. I suppose this is not a use case for the Whatsapp bot so I suggest to remove mogenius from the deployment guide.